### PR TITLE
Add parse error test cases

### DIFF
--- a/test/error/parse/ArrayDimensionsTooMany.mod
+++ b/test/error/parse/ArrayDimensionsTooMany.mod
@@ -1,0 +1,3 @@
+MODULE ArrayDimensionsTooMany;
+TYPE T = ARRAY 1,1,1,1,1,1,1,1 OF INTEGER;
+END ArrayDimensionsTooMany.

--- a/test/error/parse/EndModuleNameNotMatch.mod
+++ b/test/error/parse/EndModuleNameNotMatch.mod
@@ -1,0 +1,2 @@
+MODULE EndModuleNameNotMatch;
+END WrongName.

--- a/test/error/parse/EndProcedureNameNotMatch.mod
+++ b/test/error/parse/EndProcedureNameNotMatch.mod
@@ -1,0 +1,5 @@
+MODULE EndProcedureNameNotMatch;
+PROCEDURE Foo;
+BEGIN
+END Bar;
+END EndProcedureNameNotMatch.

--- a/test/error/parse/ErrAstBegin.mod
+++ b/test/error/parse/ErrAstBegin.mod
@@ -1,0 +1,3 @@
+MODULE ErrAstBegin;
+CONST A = 1 DIV 0;
+END ErrAstBegin.

--- a/test/error/parse/ErrAstEnd.mod
+++ b/test/error/parse/ErrAstEnd.mod
@@ -1,0 +1,3 @@
+MODULE ErrAstEnd;
+CONST A = LSL(1, -1);
+END ErrAstEnd.

--- a/test/error/parse/ErrMin.mod
+++ b/test/error/parse/ErrMin.mod
@@ -1,0 +1,3 @@
+MODULE ErrMin;
+CONST A = 1 MOD 0;
+END ErrMin.

--- a/test/error/parse/ExcessSemicolon.mod
+++ b/test/error/parse/ExcessSemicolon.mod
@@ -1,0 +1,3 @@
+MODULE ExcessSemicolon;
+VAR a: INTEGER;;
+END ExcessSemicolon.

--- a/test/error/parse/ExpectAnotherModuleName.mod
+++ b/test/error/parse/ExpectAnotherModuleName.mod
@@ -1,0 +1,2 @@
+MODULE WrongName;
+END WrongName.

--- a/test/error/parse/ExpectAssign.mod
+++ b/test/error/parse/ExpectAssign.mod
@@ -1,0 +1,5 @@
+MODULE ExpectAssign;
+VAR a: INTEGER;
+BEGIN
+  a 1;
+END ExpectAssign.

--- a/test/error/parse/ExpectBrace1Close.mod
+++ b/test/error/parse/ExpectBrace1Close.mod
@@ -1,0 +1,4 @@
+MODULE ExpectBrace1Close;
+PROCEDURE P(x: INTEGER;
+END P;
+END ExpectBrace1Close.

--- a/test/error/parse/ExpectBrace1Open.mod
+++ b/test/error/parse/ExpectBrace1Open.mod
@@ -1,0 +1,4 @@
+MODULE ExpectBrace1Open;
+PROCEDURE P);
+END P;
+END ExpectBrace1Open.

--- a/test/error/parse/ExpectBrace2Close.mod
+++ b/test/error/parse/ExpectBrace2Close.mod
@@ -1,0 +1,5 @@
+MODULE ExpectBrace2Close;
+VAR a: ARRAY 1 OF INTEGER;
+BEGIN
+  a[0;
+END ExpectBrace2Close.

--- a/test/error/parse/ExpectBrace2Open.mod
+++ b/test/error/parse/ExpectBrace2Open.mod
@@ -1,0 +1,5 @@
+MODULE ExpectBrace2Open;
+VAR a: ARRAY 1 OF INTEGER;
+BEGIN
+  a] := 0;
+END ExpectBrace2Open.

--- a/test/error/parse/ExpectBrace3Close.mod
+++ b/test/error/parse/ExpectBrace3Close.mod
@@ -1,0 +1,5 @@
+MODULE ExpectBrace3Close;
+VAR s: SET;
+BEGIN
+  s := {1, 2;
+END ExpectBrace3Close.

--- a/test/error/parse/ExpectBrace3Open.mod
+++ b/test/error/parse/ExpectBrace3Open.mod
@@ -1,0 +1,5 @@
+MODULE ExpectBrace3Open;
+VAR s: SET;
+BEGIN
+  s := 1, 2};
+END ExpectBrace3Open.

--- a/test/error/parse/ExpectColon.mod
+++ b/test/error/parse/ExpectColon.mod
@@ -1,0 +1,3 @@
+MODULE ExpectColon;
+VAR x INTEGER;
+END ExpectColon.

--- a/test/error/parse/ExpectConstName.mod
+++ b/test/error/parse/ExpectConstName.mod
@@ -1,0 +1,3 @@
+MODULE ExpectConstName;
+CONST = 1;
+END ExpectConstName.

--- a/test/error/parse/ExpectDesignator.mod
+++ b/test/error/parse/ExpectDesignator.mod
@@ -1,0 +1,4 @@
+MODULE ExpectDesignator;
+BEGIN
+  1 := 2;
+END ExpectDesignator.

--- a/test/error/parse/ExpectDo.mod
+++ b/test/error/parse/ExpectDo.mod
@@ -1,0 +1,4 @@
+MODULE ExpectDo;
+BEGIN
+  WHILE TRUE END;
+END ExpectDo.

--- a/test/error/parse/ExpectDot.mod
+++ b/test/error/parse/ExpectDot.mod
@@ -1,0 +1,2 @@
+MODULE ExpectDot;
+END ExpectDot

--- a/test/error/parse/ExpectEnd.mod
+++ b/test/error/parse/ExpectEnd.mod
@@ -1,0 +1,5 @@
+MODULE ExpectEnd;
+BEGIN
+  IF TRUE THEN
+    ;
+  END ExpectEnd.

--- a/test/error/parse/ExpectEqual.mod
+++ b/test/error/parse/ExpectEqual.mod
@@ -1,0 +1,3 @@
+MODULE ExpectEqual;
+CONST x 1;
+END ExpectEqual.

--- a/test/error/parse/ExpectExpression.mod
+++ b/test/error/parse/ExpectExpression.mod
@@ -1,0 +1,6 @@
+MODULE ExpectExpression;
+PROCEDURE P;
+BEGIN
+  RETURN ;
+END P;
+END ExpectExpression.

--- a/test/error/parse/ExpectIdent.mod
+++ b/test/error/parse/ExpectIdent.mod
@@ -1,0 +1,3 @@
+MODULE ExpectIdent;
+VAR : INTEGER;
+END ExpectIdent.

--- a/test/error/parse/ExpectIntOrStrOrQualident.mod
+++ b/test/error/parse/ExpectIntOrStrOrQualident.mod
@@ -1,0 +1,6 @@
+MODULE ExpectIntOrStrOrQualident;
+PROCEDURE P(x: INTEGER);
+BEGIN
+  CASE x OF | 0: END;
+END P;
+END ExpectIntOrStrOrQualident.

--- a/test/error/parse/ExpectModule.mod
+++ b/test/error/parse/ExpectModule.mod
@@ -1,0 +1,1 @@
+VAR x: INTEGER;

--- a/test/error/parse/ExpectModuleName.mod
+++ b/test/error/parse/ExpectModuleName.mod
@@ -1,0 +1,2 @@
+MODULE ;
+END .

--- a/test/error/parse/ExpectOf.mod
+++ b/test/error/parse/ExpectOf.mod
@@ -1,0 +1,3 @@
+MODULE ExpectOf;
+TYPE T = ARRAY 1 INTEGER;
+END ExpectOf.

--- a/test/error/parse/ExpectProcedure.mod
+++ b/test/error/parse/ExpectProcedure.mod
@@ -1,0 +1,3 @@
+MODULE ExpectProcedure;
+PROCEDURE ;
+END ExpectProcedure.

--- a/test/error/parse/ExpectProcedureName.mod
+++ b/test/error/parse/ExpectProcedureName.mod
@@ -1,0 +1,5 @@
+MODULE ExpectProcedureName;
+PROCEDURE Foo;
+BEGIN
+END ;
+END ExpectProcedureName.

--- a/test/error/parse/ExpectRecord.mod
+++ b/test/error/parse/ExpectRecord.mod
@@ -1,0 +1,3 @@
+MODULE ExpectRecord;
+TYPE P = POINTER TO ARRAY 1 OF INTEGER;
+END ExpectRecord.

--- a/test/error/parse/ExpectSemicolon.mod
+++ b/test/error/parse/ExpectSemicolon.mod
@@ -1,0 +1,3 @@
+MODULE ExpectSemicolon;
+VAR x: INTEGER
+END ExpectSemicolon.

--- a/test/error/parse/ExpectStatement.mod
+++ b/test/error/parse/ExpectStatement.mod
@@ -1,0 +1,4 @@
+MODULE ExpectStatement;
+BEGIN
+  ,
+END ExpectStatement.

--- a/test/error/parse/ExpectStructuredType.mod
+++ b/test/error/parse/ExpectStructuredType.mod
@@ -1,0 +1,3 @@
+MODULE ExpectStructuredType;
+TYPE T = INTEGER;
+END ExpectStructuredType.

--- a/test/error/parse/ExpectThen.mod
+++ b/test/error/parse/ExpectThen.mod
@@ -1,0 +1,4 @@
+MODULE ExpectThen;
+BEGIN
+  IF TRUE END;
+END ExpectThen.

--- a/test/error/parse/ExpectTo.mod
+++ b/test/error/parse/ExpectTo.mod
@@ -1,0 +1,3 @@
+MODULE ExpectTo;
+TYPE P = POINTER ;
+END ExpectTo.

--- a/test/error/parse/ExpectType.mod
+++ b/test/error/parse/ExpectType.mod
@@ -1,0 +1,3 @@
+MODULE ExpectType;
+VAR x: ;
+END ExpectType.

--- a/test/error/parse/ExpectUntil.mod
+++ b/test/error/parse/ExpectUntil.mod
@@ -1,0 +1,4 @@
+MODULE ExpectUntil;
+BEGIN
+  REPEAT
+  END ExpectUntil.

--- a/test/error/parse/ExpectVarRecordOrPointer.mod
+++ b/test/error/parse/ExpectVarRecordOrPointer.mod
@@ -1,0 +1,5 @@
+MODULE ExpectVarRecordOrPointer;
+VAR i: INTEGER;
+BEGIN
+  i();
+END ExpectVarRecordOrPointer.

--- a/test/error/parse/FunctionWithoutBraces.mod
+++ b/test/error/parse/FunctionWithoutBraces.mod
@@ -1,0 +1,6 @@
+MODULE FunctionWithoutBraces;
+PROCEDURE Foo: INTEGER;
+BEGIN
+  RETURN 0;
+END Foo;
+END FunctionWithoutBraces.

--- a/test/error/parse/MaybeAssignInsteadEqual.mod
+++ b/test/error/parse/MaybeAssignInsteadEqual.mod
@@ -1,0 +1,5 @@
+MODULE MaybeAssignInsteadEqual;
+VAR a: INTEGER;
+BEGIN
+  a = 1;
+END MaybeAssignInsteadEqual.

--- a/test/error/parse/UnexpectStringInCaseLabel.mod
+++ b/test/error/parse/UnexpectStringInCaseLabel.mod
@@ -1,0 +1,6 @@
+MODULE UnexpectStringInCaseLabel;
+PROCEDURE Foo(c: CHAR);
+BEGIN
+  CASE c OF "abc": END;
+END Foo;
+END UnexpectStringInCaseLabel.

--- a/test/error/parse/UnexpectedContentInScript.mod
+++ b/test/error/parse/UnexpectedContentInScript.mod
@@ -1,0 +1,1 @@
+(* script with no content *)


### PR DESCRIPTION
## Summary
- turn placeholder parse error files into actual examples
- each file now contains code that should trigger its corresponding parser error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847dbdeb2e88333a4ce4df1b70ffccc