### PR TITLE
Add AST error test cases

### DIFF
--- a/test/error/ast/AddExprDifferenTypes.mod
+++ b/test/error/ast/AddExprDifferenTypes.mod
@@ -1,0 +1,5 @@
+MODULE AddExprDifferenTypes;
+VAR a: INTEGER; b: REAL; r: REAL;
+BEGIN
+  r := a + b;
+END AddExprDifferenTypes.

--- a/test/error/ast/ArrayIndexNegative.mod
+++ b/test/error/ast/ArrayIndexNegative.mod
@@ -1,0 +1,5 @@
+MODULE ArrayIndexNegative;
+VAR a: ARRAY 10 OF INTEGER;
+BEGIN
+  a[-1];
+END ArrayIndexNegative.

--- a/test/error/ast/ArrayIndexNotInt.mod
+++ b/test/error/ast/ArrayIndexNotInt.mod
@@ -1,0 +1,5 @@
+MODULE ArrayIndexNotInt;
+VAR a: ARRAY 1 OF INTEGER; b: CHAR;
+BEGIN
+  a[b];
+END ArrayIndexNotInt.

--- a/test/error/ast/ArrayIndexOutOfRange.mod
+++ b/test/error/ast/ArrayIndexOutOfRange.mod
@@ -1,0 +1,5 @@
+MODULE ArrayIndexOutOfRange;
+VAR a: ARRAY 5 OF INTEGER;
+BEGIN
+  a[5];
+END ArrayIndexOutOfRange.

--- a/test/error/ast/ArrayItemToNotArray.mod
+++ b/test/error/ast/ArrayItemToNotArray.mod
@@ -1,0 +1,5 @@
+MODULE ArrayItemToNotArray;
+VAR i: INTEGER;
+BEGIN
+  i := i[0];
+END ArrayItemToNotArray.

--- a/test/error/ast/ArrayLenLess1.mod
+++ b/test/error/ast/ArrayLenLess1.mod
@@ -1,0 +1,3 @@
+MODULE ArrayLenLess1;
+TYPE A = ARRAY 0 OF INTEGER;
+END ArrayLenLess1.

--- a/test/error/ast/ArrayLenTooBig.mod
+++ b/test/error/ast/ArrayLenTooBig.mod
@@ -1,0 +1,3 @@
+MODULE ArrayLenTooBig;
+TYPE A = ARRAY 100000000 OF INTEGER;
+END ArrayLenTooBig.

--- a/test/error/ast/AssignExpectVarParam.mod
+++ b/test/error/ast/AssignExpectVarParam.mod
@@ -1,0 +1,8 @@
+MODULE AssignExpectVarParam;
+PROCEDURE Fn(): INTEGER;
+BEGIN
+  RETURN 0
+END Fn;
+BEGIN
+  Fn() := 1;
+END AssignExpectVarParam.

--- a/test/error/ast/AssignIncompatibleType.mod
+++ b/test/error/ast/AssignIncompatibleType.mod
@@ -1,0 +1,5 @@
+MODULE AssignIncompatibleType;
+VAR i: INTEGER; r: REAL;
+BEGIN
+  i := r;
+END AssignIncompatibleType.

--- a/test/error/ast/AssignStringToNotEnoughArray.mod
+++ b/test/error/ast/AssignStringToNotEnoughArray.mod
@@ -1,0 +1,5 @@
+MODULE AssignStringToNotEnoughArray;
+VAR a: ARRAY 2 OF CHAR;
+BEGIN
+  a := "abc";
+END AssignStringToNotEnoughArray.

--- a/test/error/ast/BadModule.mod
+++ b/test/error/ast/BadModule.mod
@@ -1,0 +1,4 @@
+MODULE BadModule;
+BEGIN
+  x := 1;
+END BadModule.

--- a/test/error/ast/CallAdrParamTypeWithPtr.mod
+++ b/test/error/ast/CallAdrParamTypeWithPtr.mod
@@ -1,0 +1,7 @@
+MODULE CallAdrParamTypeWithPtr;
+IMPORT SYSTEM;
+TYPE Rec = RECORD p: POINTER TO RECORD END END;
+VAR r: Rec; a: SYSTEM.ADDRESS;
+BEGIN
+  a := SYSTEM.ADR(r);
+END CallAdrParamTypeWithPtr.

--- a/test/error/ast/CallExcessParam.mod
+++ b/test/error/ast/CallExcessParam.mod
@@ -1,0 +1,5 @@
+MODULE CallExcessParam;
+PROCEDURE P; END P;
+BEGIN
+  P(1);
+END CallExcessParam.

--- a/test/error/ast/CallExpectAddressableParam.mod
+++ b/test/error/ast/CallExpectAddressableParam.mod
@@ -1,0 +1,6 @@
+MODULE CallExpectAddressableParam;
+IMPORT SYSTEM;
+VAR a: SYSTEM.ADDRESS;
+BEGIN
+  a := SYSTEM.ADR(0);
+END CallExpectAddressableParam.

--- a/test/error/ast/CallExpectVarParam.mod
+++ b/test/error/ast/CallExpectVarParam.mod
@@ -1,0 +1,5 @@
+MODULE CallExpectVarParam;
+PROCEDURE P(VAR x: INTEGER); END P;
+BEGIN
+  P(1);
+END CallExpectVarParam.

--- a/test/error/ast/CallExprWithoutReturn.mod
+++ b/test/error/ast/CallExprWithoutReturn.mod
@@ -1,0 +1,6 @@
+MODULE CallExprWithoutReturn;
+PROCEDURE P; END P;
+VAR i: INTEGER;
+BEGIN
+  i := P();
+END CallExprWithoutReturn.

--- a/test/error/ast/CallIgnoredReturn.mod
+++ b/test/error/ast/CallIgnoredReturn.mod
@@ -1,0 +1,8 @@
+MODULE CallIgnoredReturn;
+PROCEDURE F(): INTEGER;
+BEGIN
+  RETURN 0
+END F;
+BEGIN
+  F;
+END CallIgnoredReturn.

--- a/test/error/ast/CallIncompatibleParamType.mod
+++ b/test/error/ast/CallIncompatibleParamType.mod
@@ -1,0 +1,5 @@
+MODULE CallIncompatibleParamType;
+PROCEDURE P(x: INTEGER); END P;
+BEGIN
+  P(1.5);
+END CallIncompatibleParamType.

--- a/test/error/ast/CallNotProc.mod
+++ b/test/error/ast/CallNotProc.mod
@@ -1,0 +1,5 @@
+MODULE CallNotProc;
+VAR i: INTEGER;
+BEGIN
+  i();
+END CallNotProc.

--- a/test/error/ast/CallParamsNotEnough.mod
+++ b/test/error/ast/CallParamsNotEnough.mod
@@ -1,0 +1,5 @@
+MODULE CallParamsNotEnough;
+PROCEDURE P(x, y: INTEGER); END P;
+BEGIN
+  P(1);
+END CallParamsNotEnough.

--- a/test/error/ast/CallVarPointerTypeNotSame.mod
+++ b/test/error/ast/CallVarPointerTypeNotSame.mod
@@ -1,0 +1,8 @@
+MODULE CallVarPointerTypeNotSame;
+TYPE P0 = POINTER TO RECORD END;
+TYPE P1 = POINTER TO RECORD END;
+PROCEDURE Take(VAR p: P0); END Take;
+VAR q: P1;
+BEGIN
+  Take(q);
+END CallVarPointerTypeNotSame.

--- a/test/error/ast/CaseElemDuplicate.mod
+++ b/test/error/ast/CaseElemDuplicate.mod
@@ -1,0 +1,8 @@
+MODULE CaseElemDuplicate;
+VAR x: INTEGER;
+BEGIN
+  CASE x OF
+    1: ;
+    1: ;
+  END;
+END CaseElemDuplicate.

--- a/test/error/ast/CaseElemExprTypeMismatch.mod
+++ b/test/error/ast/CaseElemExprTypeMismatch.mod
@@ -1,0 +1,5 @@
+MODULE CaseElemExprTypeMismatch;
+VAR x: INTEGER;
+BEGIN
+  CASE x OF 1, 'a': END;
+END CaseElemExprTypeMismatch.

--- a/test/error/ast/CaseElseAlreadyExist.mod
+++ b/test/error/ast/CaseElseAlreadyExist.mod
@@ -1,0 +1,11 @@
+MODULE CaseElseAlreadyExist;
+VAR x: INTEGER;
+BEGIN
+  CASE x OF
+    0: ;
+  ELSE
+    ;
+  ELSE
+    ;
+  END;
+END CaseElseAlreadyExist.

--- a/test/error/ast/CaseExprWrongType.mod
+++ b/test/error/ast/CaseExprWrongType.mod
@@ -1,0 +1,7 @@
+MODULE CaseExprWrongType;
+VAR r: REAL;
+BEGIN
+  CASE r OF
+  | 0: 
+  END;
+END CaseExprWrongType.

--- a/test/error/ast/CaseLabelLeftNotLessRight.mod
+++ b/test/error/ast/CaseLabelLeftNotLessRight.mod
@@ -1,0 +1,7 @@
+MODULE CaseLabelLeftNotLessRight;
+VAR x: INTEGER;
+BEGIN
+  CASE x OF
+    5 .. 2:
+  END;
+END CaseLabelLeftNotLessRight.

--- a/test/error/ast/CaseLabelNotConst.mod
+++ b/test/error/ast/CaseLabelNotConst.mod
@@ -1,0 +1,5 @@
+MODULE CaseLabelNotConst;
+VAR x, y: INTEGER;
+BEGIN
+  CASE x OF y: ; END;
+END CaseLabelNotConst.

--- a/test/error/ast/CaseLabelNotRecExt.mod
+++ b/test/error/ast/CaseLabelNotRecExt.mod
@@ -1,0 +1,8 @@
+MODULE CaseLabelNotRecExt;
+TYPE R0 = RECORD END;
+TYPE R1 = RECORD END;
+PROCEDURE P(x: R0);
+BEGIN
+  CASE x OF R1: END;
+END P;
+END CaseLabelNotRecExt.

--- a/test/error/ast/CaseLabelWrongType.mod
+++ b/test/error/ast/CaseLabelWrongType.mod
@@ -1,0 +1,5 @@
+MODULE CaseLabelWrongType;
+VAR x: INTEGER;
+BEGIN
+  CASE x OF TRUE: END;
+END CaseLabelWrongType.

--- a/test/error/ast/CasePointerVarParam.mod
+++ b/test/error/ast/CasePointerVarParam.mod
@@ -1,0 +1,7 @@
+MODULE CasePointerVarParam;
+TYPE P = POINTER TO RECORD END;
+PROCEDURE P0(VAR x: P);
+BEGIN
+  CASE x OF | P: END;
+END P0;
+END CasePointerVarParam.

--- a/test/error/ast/CaseRangeLabelsTypeMismatch.mod
+++ b/test/error/ast/CaseRangeLabelsTypeMismatch.mod
@@ -1,0 +1,7 @@
+MODULE CaseRangeLabelsTypeMismatch;
+VAR x: INTEGER;
+BEGIN
+  CASE x OF
+    1 .. 'a':
+  END;
+END CaseRangeLabelsTypeMismatch.

--- a/test/error/ast/CaseRecordNotLocalVar.mod
+++ b/test/error/ast/CaseRecordNotLocalVar.mod
@@ -1,0 +1,8 @@
+MODULE CaseRecordNotLocalVar;
+TYPE R = RECORD a: INTEGER END;
+VAR g: R;
+PROCEDURE P;
+BEGIN
+  CASE g OF | R: END;
+END P;
+END CaseRecordNotLocalVar.

--- a/test/error/ast/CaseRecordNotParam.mod
+++ b/test/error/ast/CaseRecordNotParam.mod
@@ -1,0 +1,8 @@
+MODULE CaseRecordNotParam;
+TYPE R = RECORD END;
+VAR r: R;
+PROCEDURE P;
+BEGIN
+  CASE r OF | R: END;
+END P;
+END CaseRecordNotParam.

--- a/test/error/ast/ConstDeclExprNotConst.mod
+++ b/test/error/ast/ConstDeclExprNotConst.mod
@@ -1,0 +1,4 @@
+MODULE ConstDeclExprNotConst;
+VAR x: INTEGER;
+CONST c = x;
+END ConstDeclExprNotConst.

--- a/test/error/ast/ConstRecursive.mod
+++ b/test/error/ast/ConstRecursive.mod
@@ -1,0 +1,3 @@
+MODULE ConstRecursive;
+CONST A = A;
+END ConstRecursive.

--- a/test/error/ast/DeclarationIsPrivate.mod
+++ b/test/error/ast/DeclarationIsPrivate.mod
@@ -1,0 +1,5 @@
+MODULE DeclarationIsPrivate;
+IMPORT PrivateDeclProvider;
+BEGIN
+  PrivateDeclProvider.Hidden;
+END DeclarationIsPrivate.

--- a/test/error/ast/DeclarationNameDuplicate.mod
+++ b/test/error/ast/DeclarationNameDuplicate.mod
@@ -1,0 +1,4 @@
+MODULE DeclarationNameDuplicate;
+VAR a: INTEGER;
+VAR a: INTEGER;
+END DeclarationNameDuplicate.

--- a/test/error/ast/DeclarationNameHide.mod
+++ b/test/error/ast/DeclarationNameHide.mod
@@ -1,0 +1,10 @@
+MODULE DeclarationNameHide;
+VAR x: INTEGER;
+
+PROCEDURE P;
+VAR x: INTEGER;
+BEGIN
+  x := 0;
+END P;
+
+END DeclarationNameHide.

--- a/test/error/ast/DeclarationNotFound.mod
+++ b/test/error/ast/DeclarationNotFound.mod
@@ -1,0 +1,4 @@
+MODULE DeclarationNotFound;
+BEGIN
+  a := 1;
+END DeclarationNotFound.

--- a/test/error/ast/DerefToNotPointer.mod
+++ b/test/error/ast/DerefToNotPointer.mod
@@ -1,0 +1,5 @@
+MODULE DerefToNotPointer;
+VAR i: INTEGER;
+BEGIN
+  i := i^;
+END DerefToNotPointer.

--- a/test/error/ast/DivExprDifferentTypes.mod
+++ b/test/error/ast/DivExprDifferentTypes.mod
@@ -1,0 +1,5 @@
+MODULE DivExprDifferentTypes;
+VAR a: INTEGER; b: REAL; x: REAL;
+BEGIN
+  x := a / b;
+END DivExprDifferentTypes.

--- a/test/error/ast/ExpectReturn.mod
+++ b/test/error/ast/ExpectReturn.mod
@@ -1,0 +1,6 @@
+MODULE ExpectReturn;
+PROCEDURE P(): INTEGER;
+BEGIN
+  IF FALSE THEN RETURN 1 END;
+END P;
+END ExpectReturn.

--- a/test/error/ast/ExprInLeftNotInteger.mod
+++ b/test/error/ast/ExprInLeftNotInteger.mod
@@ -1,0 +1,5 @@
+MODULE ExprInLeftNotInteger;
+VAR b: BOOLEAN;
+BEGIN
+  b := 1.5 IN {1};
+END ExprInLeftNotInteger.

--- a/test/error/ast/ExprInRightNotSet.mod
+++ b/test/error/ast/ExprInRightNotSet.mod
@@ -1,0 +1,5 @@
+MODULE ExprInRightNotSet;
+VAR b: BOOLEAN;
+BEGIN
+  b := 1 IN 1;
+END ExprInRightNotSet.

--- a/test/error/ast/ExprInWrongTypes.mod
+++ b/test/error/ast/ExprInWrongTypes.mod
@@ -1,0 +1,5 @@
+MODULE ExprInWrongTypes;
+VAR b: BOOLEAN;
+BEGIN
+  b := 1.5 IN 1;
+END ExprInWrongTypes.

--- a/test/error/ast/ImportLoopA.mod
+++ b/test/error/ast/ImportLoopA.mod
@@ -1,0 +1,3 @@
+MODULE ImportLoopA;
+IMPORT ImportLoopB;
+END ImportLoopA.

--- a/test/error/ast/ImportLoopB.mod
+++ b/test/error/ast/ImportLoopB.mod
@@ -1,0 +1,3 @@
+MODULE ImportLoopB;
+IMPORT ImportLoopA;
+END ImportLoopB.

--- a/test/error/ast/ImportModuleNotFound.mod
+++ b/test/error/ast/ImportModuleNotFound.mod
@@ -1,0 +1,3 @@
+MODULE ImportModuleNotFound;
+IMPORT NoSuchModule;
+END ImportModuleNotFound.

--- a/test/error/ast/ImportModuleWithError.mod
+++ b/test/error/ast/ImportModuleWithError.mod
@@ -1,0 +1,3 @@
+MODULE ImportModuleWithError;
+IMPORT BadModule;
+END ImportModuleWithError.

--- a/test/error/ast/ImportNameDuplicate.mod
+++ b/test/error/ast/ImportNameDuplicate.mod
@@ -1,0 +1,3 @@
+MODULE ImportNameDuplicate;
+IMPORT Out, Out;
+END ImportNameDuplicate.

--- a/test/error/ast/ImportSelf.mod
+++ b/test/error/ast/ImportSelf.mod
@@ -1,0 +1,3 @@
+MODULE ImportSelf;
+IMPORT ImportSelf;
+END ImportSelf.

--- a/test/error/ast/InfiniteCall.mod
+++ b/test/error/ast/InfiniteCall.mod
@@ -1,0 +1,6 @@
+MODULE InfiniteCall;
+PROCEDURE P;
+BEGIN
+  P();
+END P;
+END InfiniteCall.

--- a/test/error/ast/IsEqualProc.mod
+++ b/test/error/ast/IsEqualProc.mod
@@ -1,0 +1,6 @@
+MODULE IsEqualProc;
+PROCEDURE P; END P;
+VAR t: BOOLEAN;
+BEGIN
+  t := P = P;
+END IsEqualProc.

--- a/test/error/ast/IsExtExpectFormalParam.mod
+++ b/test/error/ast/IsExtExpectFormalParam.mod
@@ -1,0 +1,12 @@
+MODULE IsExtExpectFormalParam;
+TYPE Base = RECORD END;
+TYPE Ext = RECORD(Base) END;
+VAR b: Base;
+
+PROCEDURE P(x: Base);
+VAR r: BOOLEAN;
+BEGIN
+  r := b IS Ext;
+END P;
+
+END IsExtExpectFormalParam.

--- a/test/error/ast/IsExtExpectRecordExt.mod
+++ b/test/error/ast/IsExtExpectRecordExt.mod
@@ -1,0 +1,8 @@
+MODULE IsExtExpectRecordExt;
+TYPE R0 = RECORD END;
+TYPE P0 = POINTER TO R0;
+TYPE R1 = RECORD END;
+VAR p: P0; b: BOOLEAN;
+BEGIN
+  b := p IS R1;
+END IsExtExpectRecordExt.

--- a/test/error/ast/IsExtMeshupPtrAndRecord.mod
+++ b/test/error/ast/IsExtMeshupPtrAndRecord.mod
@@ -1,0 +1,7 @@
+MODULE IsExtMeshupPtrAndRecord;
+TYPE R0 = RECORD END;
+TYPE P0 = POINTER TO R0;
+VAR p: P0; b: BOOLEAN;
+BEGIN
+  b := p IS R0;
+END IsExtMeshupPtrAndRecord.

--- a/test/error/ast/IsExtTypeNotRecord.mod
+++ b/test/error/ast/IsExtTypeNotRecord.mod
@@ -1,0 +1,6 @@
+MODULE IsExtTypeNotRecord;
+TYPE T* = POINTER TO RECORD END;
+VAR p: T; b: BOOLEAN;
+BEGIN
+  b := p IS INTEGER;
+END IsExtTypeNotRecord.

--- a/test/error/ast/IsExtVarNotRecord.mod
+++ b/test/error/ast/IsExtVarNotRecord.mod
@@ -1,0 +1,6 @@
+MODULE IsExtVarNotRecord;
+TYPE R = RECORD END;
+VAR i: INTEGER; b: BOOLEAN;
+BEGIN
+  b := i IS R;
+END IsExtVarNotRecord.

--- a/test/error/ast/MultExprDifferentTypes.mod
+++ b/test/error/ast/MultExprDifferentTypes.mod
@@ -1,0 +1,5 @@
+MODULE MultExprDifferentTypes;
+VAR a: INTEGER; b: REAL; x: REAL;
+BEGIN
+  x := a * b;
+END MultExprDifferentTypes.

--- a/test/error/ast/NotBoolInLogicExpr.mod
+++ b/test/error/ast/NotBoolInLogicExpr.mod
@@ -1,0 +1,5 @@
+MODULE NotBoolInLogicExpr;
+VAR a: INTEGER; b: BOOLEAN; c: BOOLEAN;
+BEGIN
+  c := b & a;
+END NotBoolInLogicExpr.

--- a/test/error/ast/NotIntInDivOrMod.mod
+++ b/test/error/ast/NotIntInDivOrMod.mod
@@ -1,0 +1,5 @@
+MODULE NotIntInDivOrMod;
+VAR a: REAL; b: REAL; i: INTEGER;
+BEGIN
+  i := a DIV b;
+END NotIntInDivOrMod.

--- a/test/error/ast/NotIntSetElem.mod
+++ b/test/error/ast/NotIntSetElem.mod
@@ -1,0 +1,5 @@
+MODULE NotIntSetElem;
+VAR s: SET;
+BEGIN
+  s := {1, 2.5};
+END NotIntSetElem.

--- a/test/error/ast/NotNumberAndNotSetInAdd.mod
+++ b/test/error/ast/NotNumberAndNotSetInAdd.mod
@@ -1,0 +1,5 @@
+MODULE NotNumberAndNotSetInAdd;
+VAR b: BOOLEAN; i: INTEGER; r: INTEGER;
+BEGIN
+  r := b + i;
+END NotNumberAndNotSetInAdd.

--- a/test/error/ast/NotNumberAndNotSetInMult.mod
+++ b/test/error/ast/NotNumberAndNotSetInMult.mod
@@ -1,0 +1,5 @@
+MODULE NotNumberAndNotSetInMult;
+VAR b: BOOLEAN; i: INTEGER; r: INTEGER;
+BEGIN
+  r := b * i;
+END NotNumberAndNotSetInMult.

--- a/test/error/ast/NotRealTypeForRealDiv.mod
+++ b/test/error/ast/NotRealTypeForRealDiv.mod
@@ -1,0 +1,5 @@
+MODULE NotRealTypeForRealDiv;
+VAR a, b: INTEGER; r: REAL;
+BEGIN
+  r := a / b;
+END NotRealTypeForRealDiv.

--- a/test/error/ast/PredefinedNameHide.mod
+++ b/test/error/ast/PredefinedNameHide.mod
@@ -1,0 +1,4 @@
+MODULE PredefinedNameHide;
+PROCEDURE ABS;
+END ABS;
+END PredefinedNameHide.

--- a/test/error/ast/PrivateDeclProvider.mod
+++ b/test/error/ast/PrivateDeclProvider.mod
@@ -1,0 +1,4 @@
+MODULE PrivateDeclProvider;
+PROCEDURE Hidden;
+END Hidden;
+END PrivateDeclProvider.

--- a/test/error/ast/ProcHasNoReturn.mod
+++ b/test/error/ast/ProcHasNoReturn.mod
@@ -1,0 +1,5 @@
+MODULE ProcHasNoReturn;
+PROCEDURE P(): INTEGER;
+BEGIN
+END P;
+END ProcHasNoReturn.

--- a/test/error/ast/RelIncompatibleType.mod
+++ b/test/error/ast/RelIncompatibleType.mod
@@ -1,0 +1,5 @@
+MODULE RelIncompatibleType;
+VAR a, b: SET; t: BOOLEAN;
+BEGIN
+  t := a < b;
+END RelIncompatibleType.

--- a/test/error/ast/RelationExprDifferenTypes.mod
+++ b/test/error/ast/RelationExprDifferenTypes.mod
@@ -1,0 +1,5 @@
+MODULE RelationExprDifferenTypes;
+VAR a: INTEGER; b: REAL; t: BOOLEAN;
+BEGIN
+  t := a = b;
+END RelationExprDifferenTypes.

--- a/test/error/ast/ReturnIncompatibleType.mod
+++ b/test/error/ast/ReturnIncompatibleType.mod
@@ -1,0 +1,6 @@
+MODULE ReturnIncompatibleType;
+PROCEDURE P(): INTEGER;
+BEGIN
+  RETURN 'a';
+END P;
+END ReturnIncompatibleType.

--- a/test/error/ast/SetElemMaxNotConvertToInt.mod
+++ b/test/error/ast/SetElemMaxNotConvertToInt.mod
@@ -1,0 +1,6 @@
+MODULE SetElemMaxNotConvertToInt;
+VAR s: SET; i: INTEGER;
+BEGIN
+  s := {0..31};
+  i := ORD(s);
+END SetElemMaxNotConvertToInt.

--- a/test/error/ast/SetElemOutOfLongRange.mod
+++ b/test/error/ast/SetElemOutOfLongRange.mod
@@ -1,0 +1,5 @@
+MODULE SetElemOutOfLongRange;
+VAR s: LONGSET;
+BEGIN
+  s := {100};
+END SetElemOutOfLongRange.

--- a/test/error/ast/SetElemOutOfRange.mod
+++ b/test/error/ast/SetElemOutOfRange.mod
@@ -1,0 +1,5 @@
+MODULE SetElemOutOfRange;
+VAR s: SET;
+BEGIN
+  s := {33};
+END SetElemOutOfRange.

--- a/test/error/ast/SetFromLongSet.mod
+++ b/test/error/ast/SetFromLongSet.mod
@@ -1,0 +1,6 @@
+MODULE SetFromLongSet;
+VAR ls: LONGSET; s: SET;
+BEGIN
+  ls := {1, 32};
+  s := ls;
+END SetFromLongSet.

--- a/test/error/ast/SetLeftElemBiggerRightElem.mod
+++ b/test/error/ast/SetLeftElemBiggerRightElem.mod
@@ -1,0 +1,5 @@
+MODULE SetLeftElemBiggerRightElem;
+VAR s: SET;
+BEGIN
+  s := {5 .. 2};
+END SetLeftElemBiggerRightElem.

--- a/test/error/ast/SignForBool.mod
+++ b/test/error/ast/SignForBool.mod
@@ -1,0 +1,5 @@
+MODULE SignForBool;
+VAR b: BOOLEAN; i: INTEGER;
+BEGIN
+  i := -b;
+END SignForBool.


### PR DESCRIPTION
## Summary
- add more negative tests under `test/error/ast`
- cover further `Ast` diagnostics such as wrong CASE labels, missing return, module import errors and array indexing issues

## Testing
- `./init.sh`
- `result/bs-ost run make.Build -infr . -m source`
- `result/ost run make.Test -infr . -m source`


------
https://chatgpt.com/codex/tasks/task_e_68488dd4cf288333964519c57aa2b630